### PR TITLE
写真のクロップページの機能を実装

### DIFF
--- a/web/src/components/ImageCropper.tsx
+++ b/web/src/components/ImageCropper.tsx
@@ -83,11 +83,11 @@ function operateCrop(
     dest.toBlob(
       (blob) => {
         if (!blob) throw new Error(); // this should not happen
-        const filename = `${randomString(16)}.jpg`;
-        const file = new File([blob], filename, { type: "image/jpeg" });
+        const filename = `${randomString(16)}.png`;
+        const file = new File([blob], filename, { type: "image/png" });
         resolve(file);
       },
-      "image/jpeg",
+      "image/png",
       1.0,
     );
 

--- a/web/src/components/human/WithFallback.tsx
+++ b/web/src/components/human/WithFallback.tsx
@@ -10,6 +10,7 @@ type Props = {
 export function AvatarWithFallback({ width, height, url }: Props) {
   return (
     <ImageFallback
+      key={url}
       width={width}
       height={height}
       url={url}

--- a/web/src/routes/registration/index.tsx
+++ b/web/src/routes/registration/index.tsx
@@ -80,7 +80,7 @@ export default function RegistrationPage() {
       sx={{
         position: "absolute",
         top: "56px",
-        bottom: "56px",
+        bottom: 0,
         left: 0,
         right: 0,
         overflowY: "auto",

--- a/web/src/routes/registration/steps/step1.tsx
+++ b/web/src/routes/registration/steps/step1.tsx
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Select,
   TextField,
+  Typography,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material";
 import { NextButton, type StepProps } from "../common";
@@ -75,6 +76,7 @@ export default function Step1({ onSave, prev, caller }: StepProps<Step1Data>) {
 
   return (
     <Box mt={2} mx={2} display="flex" flexDirection="column" gap={2}>
+      <Typography>アカウント設定</Typography>
       <FormControl fullWidth>
         <TextField
           value={name}

--- a/web/src/routes/registration/steps/step3.tsx
+++ b/web/src/routes/registration/steps/step3.tsx
@@ -101,9 +101,7 @@ export default function Step3({
         </Box>
       </Modal>
       <div style={{ textAlign: "center" }}>
-        <p>
-          <UserAvatar width="300px" height="300px" pictureUrl={url} />
-        </p>
+        <UserAvatar width="300px" height="300px" pictureUrl={url} />
         <PhotoPreviewButton text="写真を選択" onSelect={() => setOpen(true)} />
         {errorMessage && <span>{errorMessage}</span>}
         <Button onClick={back}>戻る</Button>

--- a/web/src/routes/registration/steps/step3.tsx
+++ b/web/src/routes/registration/steps/step3.tsx
@@ -1,9 +1,10 @@
-import { Box, Button, Modal } from "@mui/material";
+import { Box, Button, Modal, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 import {
   PhotoPreview,
   PhotoPreviewButton,
 } from "../../../components/config/PhotoPreview";
+import UserAvatar from "../../../components/human/avatar";
 import { uploadImage } from "../../../firebase/store/photo";
 import { type BackProp, NextButton, type StepProps } from "../common";
 
@@ -19,7 +20,7 @@ export default function Step3({
 }: StepProps<Step3Data> & BackProp) {
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [file, setFile] = useState<File>();
-  const [url, setURL] = useState<string>();
+  const [url, setURL] = useState<string>("");
 
   async function next() {
     if (!url) throw new Error("画像は入力必須");
@@ -62,6 +63,7 @@ export default function Step3({
   }, [open]);
   return (
     <>
+      <Typography>アイコン設定</Typography>
       <Modal
         id="MODAL"
         open={true}
@@ -100,13 +102,7 @@ export default function Step3({
       </Modal>
       <div style={{ textAlign: "center" }}>
         <p>
-          {url && (
-            <img
-              alt="選択した写真のプレビュー"
-              style={{ width: 300, height: 300 }}
-              src={url}
-            />
-          )}
+          <UserAvatar width="300px" height="300px" pictureUrl={url} />
         </p>
         <PhotoPreviewButton text="写真を選択" onSelect={() => setOpen(true)} />
         {errorMessage && <span>{errorMessage}</span>}


### PR DESCRIPTION
<!--
Pull Requestのテンプレートを作ってみました。
これに従って書けば、わかりやすいPRを出せるかなと。
変更したい場合は、`/.github/pull_request_template.md` を修正して下さい。
-->
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてもいいです -->


# PRの概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
<!-- 以下のように書くと Issue にリンクでき、マージ時に自動で Issue を閉じられる-->
写真のクロップページの機能を実装

# 具体的な変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
デフォルトのAvatarがあるなかで、写真をクロップすると、そのAvatarの部分が選択した写真になるようにした
透過画像をアップロードすると黒くなる問題を解決

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
特になし

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->



## レビューリクエストを出す前にチェック！
- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] わかりやすいPRになっているのか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
