### PR TITLE
アイコン設定画面の見た目をfigmaに合わせて変更

### DIFF
--- a/web/src/components/config/PhotoPreview.tsx
+++ b/web/src/components/config/PhotoPreview.tsx
@@ -14,8 +14,22 @@ type ButtonProps = {
 // DANGER: PhotoPreview component MUST have been rendered before this button is pressed.
 export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
   return (
-    <Button>
-      <label htmlFor="file-upload" className="custom-file-label">
+    <Button
+      variant="contained"
+      style={{
+        backgroundColor: "#039BE5",
+        color: "white",
+        width: "70vw",
+        maxWidth: "500px",
+        height: "50px",
+        borderRadius: "25px", // 楕円にするための設定
+      }}
+    >
+      <label
+        htmlFor="file-upload"
+        className="custom-file-label"
+        style={{ fontSize: "18px" }} // 文字サイズを調整
+      >
         {text || "写真を選択"}
         <input
           id="file-upload"
@@ -25,7 +39,7 @@ export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
             onSelect();
           }}
           accept=".png, .jpeg, .jpg"
-          style={{ display: "none" }} // ? how does this even work?
+          style={{ display: "none" }}
         />
       </label>
     </Button>

--- a/web/src/routes/registration/steps/step2_img.tsx
+++ b/web/src/routes/registration/steps/step2_img.tsx
@@ -62,66 +62,79 @@ export default function Step2({
     console.log("open: ", open);
   }, [open]);
   return (
-    <div style={{ textAlign: "center", marginTop: "20px" }}>
-      <Typography>アイコン設定</Typography>
-      <Modal
-        id="MODAL"
-        open={true}
-        sx={{
-          visibility: open ? "visible" : "hidden",
-          Margin: "auto",
-          alignItems: "center",
-          justifyContent: "center",
-          display: "flex",
-        }}
+    <div>
+      <Typography
+        variant="h5"
+        style={{ textAlign: "left", marginTop: "2vh", marginLeft: "10px" }}
       >
-        <Box
-          style={{
-            backgroundColor: "white",
-            width: "90%",
-            height: "auto",
-            padding: "20px",
+        アイコンを設定
+      </Typography>
+
+      <div style={{ textAlign: "center", marginTop: "15vh" }}>
+        <Modal
+          id="MODAL"
+          open={true}
+          sx={{
+            visibility: open ? "visible" : "hidden",
+            Margin: "auto",
+            alignItems: "center",
+            justifyContent: "center",
+            display: "flex",
           }}
         >
-          <PhotoPreview
-            prev={prev?.pictureUrl}
-            onCrop={(f) => {
-              setFile(f);
-            }}
-          />
-          <Button
-            sx={{ float: "right", marginRight: "30px" }}
-            onClick={() => {
-              select();
-              setOpen(false);
+          <Box
+            style={{
+              backgroundColor: "white",
+              width: "90%",
+              height: "auto",
+              padding: "20px",
             }}
           >
-            切り取り
-          </Button>
-        </Box>
-      </Modal>
-      <div
-        style={{
-          textAlign: "center",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
-        <UserAvatar width="300px" height="300px" pictureUrl={url} />
-        <PhotoPreviewButton text="写真を選択" onSelect={() => setOpen(true)} />
-        {errorMessage && <span>{errorMessage}</span>}
-        <div style={{ display: "flex", flexDirection: "row" }}>
-          <Button onClick={back}>戻る</Button>
-          {file === null ? (
-            <Button disabled={true}>
-              {caller === "registration" ? "確定" : "保存"}
+            <PhotoPreview
+              prev={prev?.pictureUrl}
+              onCrop={(f) => {
+                setFile(f);
+              }}
+            />
+            <Button
+              sx={{ float: "right", marginRight: "30px" }}
+              onClick={() => {
+                select();
+                setOpen(false);
+              }}
+            >
+              切り取り
             </Button>
-          ) : (
-            <NextButton onClick={next}>
-              {caller === "registration" ? "確定" : "保存"}
-            </NextButton>
-          )}
+          </Box>
+        </Modal>
+        <div
+          style={{
+            textAlign: "center",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <UserAvatar width="35vh" height="35vh" pictureUrl={url} />
+          <div style={{ marginTop: "10vh" }}>
+            <PhotoPreviewButton
+              text="写真を選択"
+              onSelect={() => setOpen(true)}
+            />
+          </div>
+          {errorMessage && <span>{errorMessage}</span>}
+          <div style={{ display: "flex", flexDirection: "row" }}>
+            <Button onClick={back}>戻る</Button>
+            {file === null ? (
+              <Button disabled={true}>
+                {caller === "registration" ? "確定" : "保存"}
+              </Button>
+            ) : (
+              <NextButton onClick={next}>
+                {caller === "registration" ? "確定" : "保存"}
+              </NextButton>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# PRの概要
アイコン設定画面の見た目をfigmaに合わせて変更

# 具体的な変更内容
<img width="382" alt="Screenshot 2024-09-24 at 20 35 51" src="https://github.com/user-attachments/assets/c813c0bb-bd27-4b54-ba6f-0f66a491a3dd">
こんな感じにfigmaに合わせて変更

# 影響範囲
return内の<div></div>の範囲?区分?が少し変わっています。

# 補足
「写真を追加」ボタンだけmax-widthで最大値が設定されています。


## レビューリクエストを出す前にチェック！
- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] わかりやすいPRになっているのか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
