### PR TITLE
写真選択ボタンの当たり判定の修正

### DIFF
--- a/web/src/components/config/PhotoPreview.tsx
+++ b/web/src/components/config/PhotoPreview.tsx
@@ -22,6 +22,7 @@ export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
         width: "70vw",
         maxWidth: "500px",
         height: "50px",
+        marginTop: "10vh",
         borderRadius: "25px", // 楕円にするための設定
       }}
     >

--- a/web/src/components/config/PhotoPreview.tsx
+++ b/web/src/components/config/PhotoPreview.tsx
@@ -16,6 +16,7 @@ export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
   return (
     <Button
       variant="contained"
+      component="label"
       style={{
         backgroundColor: "#039BE5",
         color: "white",
@@ -24,25 +25,20 @@ export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
         height: "50px",
         marginTop: "10vh",
         borderRadius: "25px", // 楕円にするための設定
+        fontSize: "18px",
       }}
     >
-      <label
-        htmlFor="file-upload"
-        className="custom-file-label"
-        style={{ fontSize: "18px" }} // 文字サイズを調整
-      >
-        {text || "写真を選択"}
-        <input
-          id="file-upload"
-          type="file"
-          onChange={(e) => {
-            imageSelectHandler(e);
-            onSelect();
-          }}
-          accept=".png, .jpeg, .jpg"
-          style={{ display: "none" }}
-        />
-      </label>
+      {text || "写真を選択"}
+      <input
+        id="file-upload"
+        type="file"
+        onChange={(e) => {
+          imageSelectHandler(e);
+          onSelect();
+        }}
+        accept=".png, .jpeg, .jpg"
+        style={{ display: "none" }}
+      />
     </Button>
   );
 }

--- a/web/src/routes/registration/steps/step2_img.tsx
+++ b/web/src/routes/registration/steps/step2_img.tsx
@@ -116,7 +116,7 @@ export default function Step2({
           }}
         >
           <UserAvatar width="35vh" height="35vh" pictureUrl={url} />
-          <div style={{ marginTop: "10vh" }}>
+          <div>
             <PhotoPreviewButton
               text="写真を選択"
               onSelect={() => setOpen(true)}


### PR DESCRIPTION
# PRの概要
#271

## 具体的な変更内容
写真選択ボタンの当たり判定がラベルとボタンが離れてた？ので、step2ではなく、Photopreviewで位置を調整するように変更した。

## 影響範囲
特になし




## レビューリクエストを出す前にチェック！
- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [ ] テストを書いたか (server の機能追加系の場合)
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
