### PR TITLE
画像アップロード機能の改善

### DIFF
--- a/web/src/api/internal/fetch-func.ts
+++ b/web/src/api/internal/fetch-func.ts
@@ -20,8 +20,12 @@ import endpoints from "./endpoints";
 
 type URL = string;
 
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+
 export async function uploadImage(file: File): Promise<URL> {
-  console.log("sending image to server...");
+  if (file.size >= MAX_IMAGE_SIZE) {
+    throw new Error("画像のアップロードに失敗しました: 画像が大きすぎます");
+  }
   const res = await fetch(`${endpoints.picture}?token=${await getIdToken()}`, {
     method: "POST",
     headers: {

--- a/web/src/components/ImageCropper.tsx
+++ b/web/src/components/ImageCropper.tsx
@@ -75,6 +75,7 @@ function operateCrop(
 
   const src = new Image();
   src.src = srcURL;
+  // TODO: downscale the image if it's too large to upload.
   ctx.drawImage(src, diff.x, diff.y, size.w, size.h, 0, 0, size.w, size.h);
 
   return new Promise((resolve) => {

--- a/web/src/components/config/PhotoPreview.tsx
+++ b/web/src/components/config/PhotoPreview.tsx
@@ -1,5 +1,11 @@
 import { Button } from "@mui/material";
-import { type ChangeEvent, useCallback, useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { uploadImage } from "../../api/image";
 import { ImageCropper } from "../ImageCropper";
 import { photo } from "../data/photo-preview";
@@ -11,6 +17,7 @@ type ButtonProps = {
 
 // DANGER: PhotoPreview component MUST have been rendered before this button is pressed.
 export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
+  const inputRef = useRef(null);
   return (
     <Button
       variant="contained"
@@ -25,10 +32,14 @@ export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
         borderRadius: "25px", // 楕円にするための設定
         fontSize: "18px",
       }}
+      onClick={() => {
+        if (inputRef) inputRef.current.value = "";
+      }}
     >
       {text || "写真を選択"}
       <input
         id="file-upload"
+        ref={inputRef}
         type="file"
         onChange={(e) => {
           const ok = imageSelectHandler(e);

--- a/web/src/components/config/PhotoPreview.tsx
+++ b/web/src/components/config/PhotoPreview.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@mui/material";
-import { useSnackbar } from "notistack";
 import { type ChangeEvent, useCallback, useEffect, useState } from "react";
 import { uploadImage } from "../../api/image";
 import { ImageCropper } from "../ImageCropper";

--- a/web/src/components/config/PhotoPreview.tsx
+++ b/web/src/components/config/PhotoPreview.tsx
@@ -17,7 +17,7 @@ type ButtonProps = {
 
 // DANGER: PhotoPreview component MUST have been rendered before this button is pressed.
 export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
-  const inputRef = useRef(null);
+  const inputRef: React.LegacyRef<HTMLInputElement> = useRef(null);
   return (
     <Button
       variant="contained"
@@ -33,7 +33,7 @@ export function PhotoPreviewButton({ text, onSelect }: ButtonProps) {
         fontSize: "18px",
       }}
       onClick={() => {
-        if (inputRef) inputRef.current.value = "";
+        if (inputRef.current) inputRef.current.value = "";
       }}
     >
       {text || "写真を選択"}

--- a/web/src/routes/registration/steps/step2_img.tsx
+++ b/web/src/routes/registration/steps/step2_img.tsx
@@ -1,6 +1,8 @@
 import { Box, Button, Modal, Typography } from "@mui/material";
+import { enqueueSnackbar } from "notistack";
 import { useEffect, useState } from "react";
 import { uploadImage } from "../../../api/image";
+import { MAX_IMAGE_SIZE } from "../../../api/internal/fetch-func";
 import { parsePictureUrl } from "../../../common/zod/methods";
 import {
   PhotoPreview,
@@ -57,8 +59,21 @@ export default function Step2({
   async function select() {
     try {
       if (!file) throw new Error("画像は入力必須です");
-      const url = await uploadImage(file);
-      setURL(url);
+      try {
+        if (file.size >= MAX_IMAGE_SIZE) {
+          enqueueSnackbar("画像が大きすぎます", {
+            variant: "error",
+            autoHideDuration: 2000,
+          });
+          return;
+        }
+        const url = await uploadImage(file);
+        setURL(url);
+      } catch {
+        enqueueSnackbar("画像のアップロードに失敗しました", {
+          variant: "error",
+        });
+      }
     } catch (error) {
       if (error instanceof Error) {
         let errorMessages: string;


### PR DESCRIPTION
# PRの概要
close #326, close #327
画像のアップロード機能の改善

## 具体的な変更内容

### As Is

- 選択した画像のファイルサイズが大きすぎると、空のダイアログが開く
- クロップ後の画像のファイルサイズのバリデーションはせず、サーバーに弾かれると暗黙に失敗する
- 画像を一回選択したら確定以外何もできない

### To Be

- 選択した画像のファイルサイズによるブロックはしない
- クロップ後の画像のファイルサイズを事前にチェックする
- 画像を選択した後も閉じることが可能

## 影響範囲
なし

## TODO LATER
フロントエンドでの画像の圧縮 (5MB 以下にしたい)

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
