### PR TITLE
同じデータベースを使う複数のサーバーのうち一つで画像を変更すると、URL がそのサーバーに固定される問題を修正

### DIFF
--- a/server/src/database/picture.ts
+++ b/server/src/database/picture.ts
@@ -17,9 +17,7 @@ export async function set(guid: GUID, buf: Buffer): Promise<Result<string>> {
     })
     .then(() => {
       // ?update=${date} is necessary to let the browsers properly cache the image.
-      const pictureUrl = `${
-        process.env.SERVER_ORIGIN
-      }/picture/${guid}?update=${new Date().getTime()}`;
+      const pictureUrl = `/picture/${guid}?update=${new Date().getTime()}`;
       return Ok(pictureUrl);
     })
     .catch((err) => {

--- a/web/src/components/ImageFallback.tsx
+++ b/web/src/components/ImageFallback.tsx
@@ -15,10 +15,13 @@ export function ImageFallback({ width, height, url, fallback, alt }: Props) {
     url;
     setOK(true);
   }, [url]);
+  const URL = url?.startsWith("/")
+    ? `${import.meta.env.SERVER_ORIGIN}/${url}`
+    : url;
 
   return ok ? (
     <img
-      src={url}
+      src={URL}
       style={{
         width,
         height,
@@ -27,7 +30,7 @@ export function ImageFallback({ width, height, url, fallback, alt }: Props) {
         pointerEvents: "none",
       }}
       onError={() => {
-        console.log("failed to fetch image data of:", url);
+        console.log("failed to fetch image data of:", URL);
         setOK(false);
       }}
       alt={alt}

--- a/web/src/components/ImageFallback.tsx
+++ b/web/src/components/ImageFallback.tsx
@@ -16,7 +16,7 @@ export function ImageFallback({ width, height, url, fallback, alt }: Props) {
     setOK(true);
   }, [url]);
   const URL = url?.startsWith("/")
-    ? `${import.meta.env.SERVER_ORIGIN}/${url}`
+    ? `${import.meta.env.VITE_API_ENDPOINT}/${url}`
     : url;
 
   return ok ? (


### PR DESCRIPTION
# PRの概要
closes #356 
同じデータベースを使う複数のサーバーのうち一つで画像を変更すると、URL がぞのサーバーに固定される問題を修正

## 具体的な変更内容
差分見ろ。

## 影響範囲
画像の URL のフォーマットが変わる。

## 動作要件
画像の更新が必要

## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
