### PR TITLE
FriendsメニューでListItemの任意の場所のクリックでカードを開けるようにした

### DIFF
--- a/web/src/components/human/humanListItem.tsx
+++ b/web/src/components/human/humanListItem.tsx
@@ -57,28 +57,35 @@ export function HumanListItem(props: HumanListItemProps) {
         pr: 2,
       }}
     >
-      <ListItemAvatar sx={{ marginLeft: "8px" }}>
-        <Button onClick={handleOpenClick}>
-          <UserAvatar pictureUrl={pictureUrl} width="50px" height="50px" />
-        </Button>
-      </ListItemAvatar>
-      <Box
+      <Button
+        onClick={handleOpenClick}
         sx={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          marginLeft: "20px",
+          width: "100%",
+          justifyContent: "flex-start",
+          textTransform: "none",
         }}
       >
-        <Typography variant="body1" noWrap>
-          {name}
-        </Typography>
-        <Typography variant="body2" color="text.secondary" noWrap>
-          {lastMessage && lastMessage.length > 15
-            ? `${lastMessage.slice(0, 15)}...`
-            : lastMessage || ""}
-        </Typography>
-      </Box>
+        <ListItemAvatar sx={{ marginLeft: "8px" }}>
+          <UserAvatar pictureUrl={pictureUrl} width="50px" height="50px" />
+        </ListItemAvatar>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            marginLeft: "20px",
+          }}
+        >
+          <Typography variant="body1" noWrap color={"text.primary"}>
+            {name}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {lastMessage && lastMessage.length > 15
+              ? `${lastMessage.slice(0, 15)}...`
+              : lastMessage || ""}
+          </Typography>
+        </Box>
+      </Button>
       {hasDots && (
         <Box
           sx={{


### PR DESCRIPTION
<!--変更したい場合は、`/.github/pull_request_template.md` を修正して下さい。-->
# PRの概要
Friendsメニューでアイコンのクリックでしかカードが開けなくなっていたが、ListItemの全体をクリックできるようにした

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
<!-- 以下のように書くと Issue にリンクでき、マージ時に自動で Issue を閉じられる-->
<!-- closes #001 -->
close #311 

## 具体的な変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
Buttonの適用範囲とスタイルの変更

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
とくになし

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
とくになし

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
とくになし

## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
