### PR TITLE
カードを裏側でスワイプしても次のカードは表側表示になるようにした

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -1,5 +1,5 @@
 import ThreeSixtyIcon from "@mui/icons-material/ThreeSixty";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { User } from "../common/types";
 import CoursesTable from "./course/CoursesTable";
 import UserAvatar from "./human/avatar";
@@ -17,6 +17,22 @@ export function Card({ displayedUser, onFlip }: CardProps) {
     if (onFlip) onFlip(!isDisplayingBack);
   };
 
+  // biome-ignore lint: FIXME! 本来はuseEffectではなくスワイプのイベントで実装するべき
+  useEffect(() => {
+    const card = document.getElementById("card");
+
+    if (card) {
+      card.style.transition = "none";
+      setIsDisplayingBack(false);
+
+      requestAnimationFrame(() => {
+        if (card) {
+          card.style.transition = "transform 600ms";
+        }
+      });
+    }
+  }, [displayedUser]);
+
   return (
     // biome-ignore lint: this cannot just be fixed rn FIXME!
     <div
@@ -29,6 +45,7 @@ export function Card({ displayedUser, onFlip }: CardProps) {
       onClick={handleRotate}
     >
       <div
+        id="card"
         style={{
           position: "absolute",
           width: "100%",


### PR DESCRIPTION
<!--変更したい場合は、`/.github/pull_request_template.md` を修正して下さい。-->
# PRの概要
カードを裏側でスワイプしても次のカードは表側表示になるようにした

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
<!-- 以下のように書くと Issue にリンクでき、マージ時に自動で Issue を閉じられる-->
<!-- closes #001 -->
close #290

## 具体的な変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
https://github.com/user-attachments/assets/2da16d7c-efd2-4ed3-9821-1547b649c119


## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
とくになし

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
とくになし

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
本来はカードの外側に表裏のStateをおいてスワイプのイベントで管理すべきだが、そうするとカードを必要とするページ全てに影響が出るのでとりあえずuseEffectを用いた。

## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
