### PR TITLE
タブレット・PC でヘッダーとの隙間がなくなる現象を解消

### DIFF
--- a/web/src/routes/root.tsx
+++ b/web/src/routes/root.tsx
@@ -52,7 +52,10 @@ export default function Root() {
       <Box
         sx={{
           position: "absolute",
-          top: "56px",
+          top: {
+            xs: "56px",
+            sm: "64px",
+          },
           bottom: "56px",
           left: 0,
           right: 0,


### PR DESCRIPTION
<!--変更したい場合は、`/.github/pull_request_template.md` を修正して下さい。-->
# PRの概要

タブレット・PC ではヘッダーの縦幅がやや大きくなるが、それが考慮されていなかったためメインコンテンツとヘッダーとの隙間がなくなっていた。これを修正した。

Before

https://github.com/user-attachments/assets/77bf4c91-ea76-42b0-bfdf-fffcf03c2e0c


After

https://github.com/user-attachments/assets/d8f1e33a-7eae-4802-a262-a1467271c142


## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
