### PR TITLE
ホーム画面のカード周りのスタイルを調整

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -39,7 +39,7 @@ export function Card({ displayedUser, comparisonUserId, onFlip }: CardProps) {
     <div
       style={{
         perspective: "1000px",
-        width: "85vw",
+        width: "min(40dvh, 87.5vw)",
         height: "70dvh",
         position: "relative",
       }}
@@ -89,6 +89,8 @@ const CardFront = ({ displayedUser }: CardProps) => {
   return (
     <div
       style={{
+        display: "flex",
+        flexDirection: "column",
         backgroundColor: "#F7FCFF",
         border: "2px solid #3596C6",
         padding: "10px",
@@ -109,17 +111,17 @@ const CardFront = ({ displayedUser }: CardProps) => {
       >
         <UserAvatar
           pictureUrl={displayedUser?.pictureUrl}
-          width="10vh"
-          height="10vh"
+          width="10dvh"
+          height="10dvh"
         />
         {displayedUser?.name && (
           <p
             style={{
-              fontSize: "5vmin",
+              fontSize: "2.2dvh",
               fontWeight: "bold",
               gridColumn: "2 / 4",
               gridRow: "1 / 2",
-              margin: "10px",
+              margin: "1.1dvh",
               marginRight: "0",
             }}
           >
@@ -130,7 +132,7 @@ const CardFront = ({ displayedUser }: CardProps) => {
         {displayedUser?.department && (
           <p
             style={{
-              fontSize: "4vmin",
+              fontSize: "1.76dvh",
               gridColumn: "1 / 4",
               gridRow: "3 / 4",
             }}
@@ -140,7 +142,7 @@ const CardFront = ({ displayedUser }: CardProps) => {
         )}
         <p
           style={{
-            fontSize: "5vmin",
+            fontSize: "2.2dvh",
             gridColumn: "1 / 3",
             gridRow: "2 / 3",
           }}
@@ -149,20 +151,22 @@ const CardFront = ({ displayedUser }: CardProps) => {
         </p>
         <p
           style={{
-            fontSize: "5vmin",
+            fontSize: "2.2dvh",
             gridColumn: "2 / 4",
             gridRow: "4 / 5",
           }}
         >
           {displayedUser?.grade}
         </p>
-        <p style={{ fontSize: "5vmin", gridColumn: "1 / 3", gridRow: "4 / 5" }}>
+        <p
+          style={{ fontSize: "2.2dvh", gridColumn: "1 / 3", gridRow: "4 / 5" }}
+        >
           {displayedUser.gender}
         </p>
         {displayedUser?.intro && (
           <p
             style={{
-              fontSize: "4vmin",
+              fontSize: "1.76dvh",
               gridColumn: "1 / 4",
               gridRow: "5 / 8",
               alignSelf: "start",
@@ -172,9 +176,9 @@ const CardFront = ({ displayedUser }: CardProps) => {
           </p>
         )}
       </div>
-      <div style={{ position: "absolute", bottom: "0", right: "0", left: "0" }}>
+      <div>
         <ThreeSixtyIcon
-          style={{ fontSize: "7vmin", display: "block", margin: "auto" }}
+          style={{ fontSize: "3.08dvh", display: "block", margin: "auto" }}
         />
       </div>
     </div>
@@ -205,7 +209,7 @@ const CardBack = ({ displayedUser, comparisonUserId }: CardProps) => {
       />
       <div>
         <ThreeSixtyIcon
-          style={{ fontSize: "7vmin", display: "block", margin: "auto" }}
+          style={{ fontSize: "3.08dvh", display: "block", margin: "auto" }}
         />
       </div>
     </div>

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -1,4 +1,5 @@
 import ThreeSixtyIcon from "@mui/icons-material/ThreeSixty";
+import { Chip } from "@mui/material";
 import { useEffect, useState } from "react";
 import type { User, UserID } from "../common/types";
 import NonEditableCoursesTable from "./course/NonEditableCoursesTable";
@@ -93,88 +94,142 @@ const CardFront = ({ displayedUser }: CardProps) => {
         flexDirection: "column",
         backgroundColor: "#F7FCFF",
         border: "2px solid #3596C6",
-        padding: "10px",
+        padding: "20px 20px 10px 20px",
         height: "100%",
+        gap: "2dvh",
         overflow: "hidden",
+        justifyContent: "space-between",
       }}
     >
       <div
         style={{
-          padding: "10px",
           display: "grid",
           gridTemplateColumns: "1fr 1fr 1fr",
-          gridTemplateRows: "30% 10% 10% 10% 10% 10% 20%",
           alignItems: "center",
-          justifyContent: "center",
-          height: "100%",
+          height: "30%",
         }}
       >
         <UserAvatar
-          pictureUrl={displayedUser?.pictureUrl}
+          pictureUrl={displayedUser.pictureUrl}
           width="10dvh"
           height="10dvh"
         />
-        {displayedUser?.name && (
-          <p
-            style={{
-              fontSize: "2.2dvh",
-              fontWeight: "bold",
-              gridColumn: "2 / 4",
-              gridRow: "1 / 2",
-              margin: "1.1dvh",
-              marginRight: "0",
-            }}
-          >
-            {displayedUser?.name}
-          </p>
-        )}
-
-        {displayedUser?.department && (
-          <p
-            style={{
-              fontSize: "1.76dvh",
-              gridColumn: "1 / 4",
-              gridRow: "3 / 4",
-            }}
-          >
-            {displayedUser.department}
-          </p>
-        )}
-        <p
+        <div
           style={{
-            fontSize: "2.2dvh",
-            gridColumn: "1 / 3",
-            gridRow: "2 / 3",
-          }}
-        >
-          {`${displayedUser.faculty}`}
-        </p>
-        <p
-          style={{
-            fontSize: "2.2dvh",
+            display: "flex",
             gridColumn: "2 / 4",
-            gridRow: "4 / 5",
+            marginLeft: "1dvh",
+            justifyContent: "center",
           }}
         >
-          {displayedUser?.grade}
-        </p>
-        <p
-          style={{ fontSize: "2.2dvh", gridColumn: "1 / 3", gridRow: "4 / 5" }}
-        >
-          {displayedUser.gender}
-        </p>
-        {displayedUser?.intro && (
-          <p
+          <span
             style={{
-              fontSize: "1.76dvh",
-              gridColumn: "1 / 4",
-              gridRow: "5 / 8",
-              alignSelf: "start",
+              fontSize: "3.4vh",
+              fontWeight: "bold",
+              margin: "0 auto",
             }}
           >
-            {displayedUser.intro}
-          </p>
-        )}
+            {displayedUser.name}
+          </span>
+        </div>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
+          alignItems: "center",
+          gap: "1.5dvh",
+        }}
+      >
+        <Chip
+          label="学部"
+          size="small"
+          sx={{
+            gridColumn: "1 / 2",
+          }}
+        />
+        <p
+          style={{
+            margin: 0,
+            fontSize: "3dvh",
+          }}
+        >
+          {displayedUser.faculty}
+        </p>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
+          alignItems: "center",
+          gap: "1.5dvh",
+        }}
+      >
+        <Chip label="学科" size="small" />
+        <p
+          style={{
+            margin: 0,
+            fontSize: "1.76dvh",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {displayedUser.department}
+        </p>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
+          alignItems: "center",
+          gap: "1.5dvh",
+        }}
+      >
+        <Chip label="性別" size="small" />
+        <p style={{ margin: 0, fontSize: "3dvh" }}>{displayedUser.gender}</p>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
+          alignItems: "center",
+          gap: "1.5dvh",
+        }}
+      >
+        <Chip label="学年" size="small" />
+        <p style={{ margin: 0, fontSize: "3dvh" }}> {displayedUser.grade}</p>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
+          gap: "1.5dvh",
+          maxHeight: "32%", // WebKitLineClamp の フォールバックとして
+        }}
+      >
+        <Chip
+          label="自己紹介"
+          size="small"
+          sx={{
+            fontSize: "0.45rem",
+          }}
+        />
+        <p
+          style={{
+            margin: 0,
+            fontSize: "1.76dvh",
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: 8,
+            lineClamp: 8,
+            textOverflow: "ellipsis",
+          }}
+        >
+          {displayedUser.intro}
+        </p>
       </div>
       <div>
         <ThreeSixtyIcon

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -167,13 +167,23 @@ const CardFront = ({ displayedUser }: CardProps) => {
       >
         <Chip label="学科" size="small" />
         <p
-          style={{
-            margin: 0,
-            fontSize: "1.76dvh",
-            overflow: "hidden",
-            whiteSpace: "nowrap",
-            textOverflow: "ellipsis",
-          }}
+          style={
+            displayedUser.department.length <= 7
+              ? {
+                  margin: 0,
+                  fontSize: "3dvh",
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }
+              : {
+                  margin: 0,
+                  fontSize: "1.76dvh",
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }
+          }
         >
           {displayedUser.department}
         </p>

--- a/web/src/components/DraggableCard.tsx
+++ b/web/src/components/DraggableCard.tsx
@@ -54,7 +54,7 @@ export const DraggableCard = ({
               position: "absolute",
               zIndex: 2,
               backgroundColor: "rgba(255, 0, 0, 0.3)",
-              width: "85vw",
+              width: "min(40dvh, 87.5vw)",
               height: "70dvh",
               pointerEvents: "none",
               display: "flex",
@@ -69,10 +69,10 @@ export const DraggableCard = ({
               flexDirection={"column"}
               borderRadius={"50%"}
               bgcolor={"white"}
-              width={"35vw"}
-              height={"35vw"}
+              width={"16dvh"}
+              height={"16dvh"}
             >
-              <FavoriteIcon style={{ color: "red", fontSize: "10vw" }} />
+              <FavoriteIcon style={{ color: "red", fontSize: "4.5dvh" }} />
               <Typography variant="h5" component="h1" mb={1}>
                 いいね！
               </Typography>
@@ -84,7 +84,7 @@ export const DraggableCard = ({
               position: "absolute",
               zIndex: 2,
               backgroundColor: "rgba(0, 0, 0, 0.3)",
-              width: "85vw",
+              width: "min(40dvh, 87.5vw)",
               height: "70dvh",
               pointerEvents: "none",
               display: "flex",
@@ -99,10 +99,10 @@ export const DraggableCard = ({
               flexDirection={"column"}
               borderRadius={"50%"}
               bgcolor={"white"}
-              width={"35vw"}
-              height={"35vw"}
+              width={"16dvh"}
+              height={"16dvh"}
             >
-              <CloseIcon style={{ color: "black", fontSize: "10vw" }} />
+              <CloseIcon style={{ color: "black", fontSize: "4.5dvh" }} />
               <Typography variant="h5" component="h1" mb={1}>
                 スキップ
               </Typography>
@@ -114,7 +114,7 @@ export const DraggableCard = ({
               position: "absolute",
               zIndex: 2,
               backgroundColor: "rgba(0, 0, 0, 0)",
-              width: "85vw",
+              width: "min(40dvh, 87.5vw)",
               height: "70dvh",
               pointerEvents: "none",
             }}

--- a/web/src/components/course/components/CoursesTableCore/index.tsx
+++ b/web/src/components/course/components/CoursesTableCore/index.tsx
@@ -138,8 +138,32 @@ function Cell({
 }) {
   const content = (
     <>
-      <span>{courseName ? truncateStr(courseName ?? "", 16) : ""}</span>
-      <span>{teacherName ? truncateStr(teacherName ?? "", 6) : ""}</span>
+      <p
+        style={{
+          margin: 0,
+          overflow: "hidden",
+          display: "-webkit-box",
+          WebkitBoxOrient: "vertical",
+          WebkitLineClamp: 2,
+          lineClamp: 2,
+          textOverflow: "ellipsis",
+        }}
+      >
+        {courseName ? truncateStr(courseName ?? "", 16) : ""}
+      </p>
+      <p
+        style={{
+          margin: 0,
+          overflow: "hidden",
+          display: "-webkit-box",
+          WebkitBoxOrient: "vertical",
+          WebkitLineClamp: 2,
+          lineClamp: 2,
+          textOverflow: "ellipsis",
+        }}
+      >
+        {teacherName ? truncateStr(teacherName ?? "", 6) : ""}
+      </p>
     </>
   );
 
@@ -160,7 +184,7 @@ function Cell({
           {content}
         </button>
       ) : (
-        <span
+        <div
           className={
             isOverlapping
               ? styles.overlapped
@@ -170,7 +194,7 @@ function Cell({
           }
         >
           {content}
-        </span>
+        </div>
       )}
     </td>
   );

--- a/web/src/components/course/components/CoursesTableCore/styles.module.css
+++ b/web/src/components/course/components/CoursesTableCore/styles.module.css
@@ -38,7 +38,7 @@
   vertical-align: top;
 }
 
-.table > tbody > tr > td > span {
+.table > tbody > tr > td > div {
   width: 100%;
   height: 100%;
   padding: 0 0.1rem;
@@ -47,7 +47,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: 0.5rem;
+  font-size: 1dvh;
   vertical-align: top;
 }
 

--- a/web/src/routes/root.tsx
+++ b/web/src/routes/root.tsx
@@ -52,7 +52,10 @@ export default function Root() {
       <Box
         sx={{
           position: "absolute",
-          top: "56px",
+          top: {
+            xs: "56px",
+            sm: "64px",
+          },
           bottom: "56px",
           left: 0,
           right: 0,

--- a/web/src/routes/tabs/home.tsx
+++ b/web/src/routes/tabs/home.tsx
@@ -58,6 +58,7 @@ export default function Home() {
         <Box
           display="flex"
           flexDirection="column"
+          justifyContent="space-evenly"
           alignItems="center"
           height="100%"
         >

--- a/web/src/routes/tabs/home.tsx
+++ b/web/src/routes/tabs/home.tsx
@@ -70,7 +70,6 @@ export default function Home() {
           />
           <div
             style={{
-              flex: 1,
               display: "flex",
               flexDirection: "row",
               alignItems: "center",

--- a/web/src/routes/tabs/home.tsx
+++ b/web/src/routes/tabs/home.tsx
@@ -69,12 +69,12 @@ export default function Home() {
           />
           <div
             style={{
+              flex: 1,
               display: "flex",
               flexDirection: "row",
               alignItems: "center",
               justifyContent: "space-around",
-              width: "100%",
-              height: "100%",
+              width: "min(100%, 46dvh)",
               marginBottom: "10px",
             }}
           >
@@ -106,16 +106,16 @@ const RoundButton = ({ onclick, icon }: RoundButtonProps) => {
 
 const ButtonStyle = {
   borderRadius: "50%",
-  width: "15vw",
-  height: "15vw",
+  width: "7dvh",
+  height: "7dvh",
   boxShadow: shadows[10],
   backgroundColor: "white",
 };
 
 const CloseIconStyled = () => {
-  return <CloseIcon style={{ color: "grey", fontSize: "10vw" }} />;
+  return <CloseIcon style={{ color: "grey", fontSize: "4.5dvh" }} />;
 };
 
 const FavoriteIconStyled = () => {
-  return <FavoriteIcon style={{ color: "red", fontSize: "10vw" }} />;
+  return <FavoriteIcon style={{ color: "red", fontSize: "4.5dvh" }} />;
 };

--- a/web/src/routes/tabs/settings/profile.tsx
+++ b/web/src/routes/tabs/settings/profile.tsx
@@ -32,7 +32,7 @@ export default function Profile() {
     <>
       <Box
         sx={{
-          padding: "20px",
+          padding: "8px",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
@@ -41,7 +41,7 @@ export default function Profile() {
         }}
       >
         <IconButton
-          sx={{ position: "absolute", top: "20px", left: "20px", zIndex: 10 }}
+          sx={{ position: "absolute", top: "8px", left: "20px", zIndex: 10 }}
           onClick={() => {
             navigate("/settings");
           }}
@@ -52,9 +52,7 @@ export default function Profile() {
           sx={{
             width: "100%",
             maxWidth: "600px",
-            paddingTop: "30px",
-            paddingRight: "30px",
-            paddingLeft: "30px",
+            padding: "8px 8px 0px 8px",
             position: "relative",
           }}
         >
@@ -69,8 +67,8 @@ export default function Profile() {
           <Box
             sx={{
               position: "absolute",
-              top: "16px",
-              right: "16px",
+              top: "0px",
+              right: "32px",
             }}
           >
             <IconButton


### PR DESCRIPTION
## PRの概要

カード関連のスタイルを調整しました。

- 画面の縦の大きさ基準でカードのレイアウトを固定するようにしました。
- カードに「学部」「性別」などのラベルを追加しました。

https://github.com/user-attachments/assets/da98e086-cda1-4b87-a8ee-475a5112e05a

## 詳細

- close #239 
- カードごと小さくなったので close #377 


## 影響範囲

カード内部。また、カードの幅に依存するものには影響があるかもしれない

## 補足

各 PR を Squash and Merge してこの PR を作ったので、それぞれの詳細は各 PR を参照してください。

## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
