### PR TITLE
カードに「学部」「性別」などのラベルを追加

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -1,4 +1,5 @@
 import ThreeSixtyIcon from "@mui/icons-material/ThreeSixty";
+import { Chip } from "@mui/material";
 import { useEffect, useState } from "react";
 import type { User, UserID } from "../common/types";
 import NonEditableCoursesTable from "./course/NonEditableCoursesTable";
@@ -101,72 +102,104 @@ const CardFront = ({ displayedUser }: CardProps) => {
       <div
         style={{
           padding: "10px",
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
-          gridTemplateRows: "30% 10% 10% 10% 10% 10% 20%",
-          alignItems: "center",
-          justifyContent: "center",
+          display: "flex",
+          flexDirection: "column",
           height: "100%",
+          gap: "2dvh",
         }}
       >
-        <UserAvatar
-          pictureUrl={displayedUser.pictureUrl}
-          width="10dvh"
-          height="10dvh"
-        />
-        <p
+        <div
           style={{
-            fontSize: "4vh",
-            fontWeight: "bold",
-            gridColumn: "2 / 4",
-            gridRow: "1 / 2",
-            margin: "1.1dvh",
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr",
+            alignItems: "center",
+            height: "30%",
           }}
         >
-          {displayedUser.name}
-        </p>
-        <p
+          <UserAvatar
+            pictureUrl={displayedUser.pictureUrl}
+            width="10dvh"
+            height="10dvh"
+          />
+          <p
+            style={{
+              fontSize: "4vh",
+              fontWeight: "bold",
+              gridColumn: "2 / 4",
+              margin: "1.1dvh",
+            }}
+          >
+            {displayedUser.name}
+          </p>
+        </div>
+        <div
           style={{
-            fontSize: "3dvh",
-            gridColumn: "1 / 4",
-            gridRow: "2 / 3",
+            display: "flex",
+            alignItems: "center",
+            gap: "1.1dvh",
           }}
         >
-          {`${displayedUser.faculty}`}
-        </p>
-        <p
+          <Chip label="学部" size="small" />
+          <span
+            style={{
+              fontSize: "3dvh",
+            }}
+          >
+            {displayedUser.faculty}
+          </span>
+        </div>
+        <div
           style={{
-            fontSize: "1.76dvh",
-            gridColumn: "1 / 4",
-            gridRow: "3 / 4",
+            display: "flex",
+            alignItems: "center",
+            gap: "1.1dvh",
           }}
         >
-          {displayedUser.department}
-        </p>
-
-        <p
+          <Chip label="学科" size="small" />
+          <span
+            style={{
+              fontSize: "1.76dvh",
+            }}
+          >
+            {displayedUser.department}
+          </span>
+        </div>
+        <div
           style={{
-            fontSize: "3dvh",
-            gridColumn: "2 / 4",
-            gridRow: "4 / 5",
+            display: "flex",
+            alignItems: "center",
+            gap: "1.1dvh",
           }}
         >
-          {displayedUser.grade}
-        </p>
-        <p style={{ fontSize: "3dvh", gridColumn: "1 / 3", gridRow: "4 / 5" }}>
-          {displayedUser.gender}
-        </p>
-
-        <p
+          <Chip label="性別" size="small" />
+          <span style={{ fontSize: "3dvh" }}>{displayedUser.gender}</span>
+        </div>
+        <div
           style={{
-            fontSize: "1.76dvh",
-            gridColumn: "1 / 4",
-            gridRow: "5 / 8",
-            alignSelf: "start",
+            display: "flex",
+            alignItems: "center",
+            gap: "1.1dvh",
           }}
         >
-          {displayedUser.intro}
-        </p>
+          <Chip label="学年" size="small" />
+          <span style={{ fontSize: "3dvh" }}> {displayedUser.grade}</span>
+        </div>
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            gap: "1.1dvh",
+          }}
+        >
+          <Chip
+            label="自己紹介"
+            size="small"
+            sx={{
+              fontSize: "0.5rem",
+            }}
+          />
+          <span style={{ fontSize: "1.76dvh" }}>{displayedUser.intro}</span>
+        </div>
       </div>
       <div>
         <ThreeSixtyIcon

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -94,113 +94,105 @@ const CardFront = ({ displayedUser }: CardProps) => {
         flexDirection: "column",
         backgroundColor: "#F7FCFF",
         border: "2px solid #3596C6",
-        padding: "10px",
+        padding: "20px 20px 10px 20px",
         height: "100%",
+        gap: "2dvh",
         overflow: "hidden",
       }}
     >
       <div
         style={{
-          padding: "10px",
-          display: "flex",
-          flexDirection: "column",
-          height: "100%",
-          gap: "2dvh",
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          alignItems: "center",
+          height: "30%",
         }}
       >
-        <div
+        <UserAvatar
+          pictureUrl={displayedUser.pictureUrl}
+          width="10dvh"
+          height="10dvh"
+        />
+        <p
           style={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr 1fr",
-            alignItems: "center",
-            height: "30%",
+            fontSize: "4vh",
+            fontWeight: "bold",
+            gridColumn: "2 / 4",
+            margin: "1.1dvh",
           }}
         >
-          <UserAvatar
-            pictureUrl={displayedUser.pictureUrl}
-            width="10dvh"
-            height="10dvh"
-          />
-          <p
-            style={{
-              fontSize: "4vh",
-              fontWeight: "bold",
-              gridColumn: "2 / 4",
-              margin: "1.1dvh",
-            }}
-          >
-            {displayedUser.name}
-          </p>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "1.1dvh",
-          }}
-        >
-          <Chip label="学部" size="small" />
-          <span
-            style={{
-              fontSize: "3dvh",
-            }}
-          >
-            {displayedUser.faculty}
-          </span>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "1.1dvh",
-          }}
-        >
-          <Chip label="学科" size="small" />
-          <span
-            style={{
-              fontSize: "1.76dvh",
-            }}
-          >
-            {displayedUser.department}
-          </span>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "1.1dvh",
-          }}
-        >
-          <Chip label="性別" size="small" />
-          <span style={{ fontSize: "3dvh" }}>{displayedUser.gender}</span>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "1.1dvh",
-          }}
-        >
-          <Chip label="学年" size="small" />
-          <span style={{ fontSize: "3dvh" }}> {displayedUser.grade}</span>
-        </div>
-        <div
-          style={{
-            flex: 1,
-            display: "flex",
-            gap: "1.1dvh",
-          }}
-        >
-          <Chip
-            label="自己紹介"
-            size="small"
-            sx={{
-              fontSize: "0.5rem",
-            }}
-          />
-          <span style={{ fontSize: "1.76dvh" }}>{displayedUser.intro}</span>
-        </div>
+          {displayedUser.name}
+        </p>
       </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "1.1dvh",
+        }}
+      >
+        <Chip label="学部" size="small" />
+        <span
+          style={{
+            fontSize: "3dvh",
+          }}
+        >
+          {displayedUser.faculty}
+        </span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "1.1dvh",
+        }}
+      >
+        <Chip label="学科" size="small" />
+        <span
+          style={{
+            fontSize: "1.76dvh",
+          }}
+        >
+          {displayedUser.department}
+        </span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "1.1dvh",
+        }}
+      >
+        <Chip label="性別" size="small" />
+        <span style={{ fontSize: "3dvh" }}>{displayedUser.gender}</span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "1.1dvh",
+        }}
+      >
+        <Chip label="学年" size="small" />
+        <span style={{ fontSize: "3dvh" }}> {displayedUser.grade}</span>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          gap: "1.1dvh",
+        }}
+      >
+        <Chip
+          label="自己紹介"
+          size="small"
+          sx={{
+            fontSize: "0.5rem",
+          }}
+        />
+        <span style={{ fontSize: "1.76dvh" }}>{displayedUser.intro}</span>
+      </div>
+
       <div>
         <ThreeSixtyIcon
           style={{ fontSize: "3.08dvh", display: "block", margin: "auto" }}

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -98,6 +98,7 @@ const CardFront = ({ displayedUser }: CardProps) => {
         height: "100%",
         gap: "2dvh",
         overflow: "hidden",
+        justifyContent: "space-between",
       }}
     >
       <div
@@ -115,10 +116,11 @@ const CardFront = ({ displayedUser }: CardProps) => {
         />
         <p
           style={{
-            fontSize: "4vh",
+            fontSize: "3.4vh",
             fontWeight: "bold",
             gridColumn: "2 / 4",
-            margin: "1.1dvh",
+            margin: 0,
+            marginLeft: "1.2dvh",
           }}
         >
           {displayedUser.name}
@@ -126,73 +128,102 @@ const CardFront = ({ displayedUser }: CardProps) => {
       </div>
       <div
         style={{
-          display: "flex",
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
           alignItems: "center",
-          gap: "1.1dvh",
+          gap: "1.5dvh",
         }}
       >
-        <Chip label="学部" size="small" />
-        <span
+        <Chip
+          label="学部"
+          size="small"
+          sx={{
+            gridColumn: "1 / 2",
+          }}
+        />
+        <p
           style={{
+            margin: 0,
             fontSize: "3dvh",
           }}
         >
           {displayedUser.faculty}
-        </span>
+        </p>
       </div>
       <div
         style={{
-          display: "flex",
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
           alignItems: "center",
-          gap: "1.1dvh",
+          gap: "1.5dvh",
         }}
       >
         <Chip label="学科" size="small" />
-        <span
+        <p
           style={{
+            margin: 0,
             fontSize: "1.76dvh",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
           }}
         >
           {displayedUser.department}
-        </span>
+        </p>
       </div>
       <div
         style={{
-          display: "flex",
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
           alignItems: "center",
-          gap: "1.1dvh",
+          gap: "1.5dvh",
         }}
       >
         <Chip label="性別" size="small" />
-        <span style={{ fontSize: "3dvh" }}>{displayedUser.gender}</span>
+        <p style={{ margin: 0, fontSize: "3dvh" }}>{displayedUser.gender}</p>
       </div>
       <div
         style={{
-          display: "flex",
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
           alignItems: "center",
-          gap: "1.1dvh",
+          gap: "1.5dvh",
         }}
       >
         <Chip label="学年" size="small" />
-        <span style={{ fontSize: "3dvh" }}> {displayedUser.grade}</span>
+        <p style={{ margin: 0, fontSize: "3dvh" }}> {displayedUser.grade}</p>
       </div>
       <div
         style={{
           flex: 1,
-          display: "flex",
-          gap: "1.1dvh",
+          display: "grid",
+          gridTemplateColumns: "1fr 5fr",
+          gap: "1.5dvh",
+          maxHeight: "32%", // WebKitLineClamp の フォールバックとして
         }}
       >
         <Chip
           label="自己紹介"
           size="small"
           sx={{
-            fontSize: "0.5rem",
+            fontSize: "0.45rem",
           }}
         />
-        <span style={{ fontSize: "1.76dvh" }}>{displayedUser.intro}</span>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "1.76dvh",
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: 8,
+            lineClamp: 8,
+            textOverflow: "ellipsis",
+          }}
+        >
+          {displayedUser.intro}
+        </p>
       </div>
-
       <div>
         <ThreeSixtyIcon
           style={{ fontSize: "3.08dvh", display: "block", margin: "auto" }}

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -110,40 +110,25 @@ const CardFront = ({ displayedUser }: CardProps) => {
         }}
       >
         <UserAvatar
-          pictureUrl={displayedUser?.pictureUrl}
+          pictureUrl={displayedUser.pictureUrl}
           width="10dvh"
           height="10dvh"
         />
-        {displayedUser?.name && (
-          <p
-            style={{
-              fontSize: "2.2dvh",
-              fontWeight: "bold",
-              gridColumn: "2 / 4",
-              gridRow: "1 / 2",
-              margin: "1.1dvh",
-              marginRight: "0",
-            }}
-          >
-            {displayedUser?.name}
-          </p>
-        )}
-
-        {displayedUser?.department && (
-          <p
-            style={{
-              fontSize: "1.76dvh",
-              gridColumn: "1 / 4",
-              gridRow: "3 / 4",
-            }}
-          >
-            {displayedUser.department}
-          </p>
-        )}
         <p
           style={{
-            fontSize: "2.2dvh",
-            gridColumn: "1 / 3",
+            fontSize: "4vh",
+            fontWeight: "bold",
+            gridColumn: "2 / 4",
+            gridRow: "1 / 2",
+            margin: "1.1dvh",
+          }}
+        >
+          {displayedUser.name}
+        </p>
+        <p
+          style={{
+            fontSize: "3dvh",
+            gridColumn: "1 / 4",
             gridRow: "2 / 3",
           }}
         >
@@ -151,30 +136,37 @@ const CardFront = ({ displayedUser }: CardProps) => {
         </p>
         <p
           style={{
-            fontSize: "2.2dvh",
+            fontSize: "1.76dvh",
+            gridColumn: "1 / 4",
+            gridRow: "3 / 4",
+          }}
+        >
+          {displayedUser.department}
+        </p>
+
+        <p
+          style={{
+            fontSize: "3dvh",
             gridColumn: "2 / 4",
             gridRow: "4 / 5",
           }}
         >
-          {displayedUser?.grade}
+          {displayedUser.grade}
         </p>
-        <p
-          style={{ fontSize: "2.2dvh", gridColumn: "1 / 3", gridRow: "4 / 5" }}
-        >
+        <p style={{ fontSize: "3dvh", gridColumn: "1 / 3", gridRow: "4 / 5" }}>
           {displayedUser.gender}
         </p>
-        {displayedUser?.intro && (
-          <p
-            style={{
-              fontSize: "1.76dvh",
-              gridColumn: "1 / 4",
-              gridRow: "5 / 8",
-              alignSelf: "start",
-            }}
-          >
-            {displayedUser.intro}
-          </p>
-        )}
+
+        <p
+          style={{
+            fontSize: "1.76dvh",
+            gridColumn: "1 / 4",
+            gridRow: "5 / 8",
+            alignSelf: "start",
+          }}
+        >
+          {displayedUser.intro}
+        </p>
       </div>
       <div>
         <ThreeSixtyIcon

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -114,17 +114,24 @@ const CardFront = ({ displayedUser }: CardProps) => {
           width="10dvh"
           height="10dvh"
         />
-        <p
+        <div
           style={{
-            fontSize: "3.4vh",
-            fontWeight: "bold",
+            display: "flex",
             gridColumn: "2 / 4",
-            margin: 0,
-            marginLeft: "1.2dvh",
+            marginLeft: "1dvh",
+            justifyContent: "center",
           }}
         >
-          {displayedUser.name}
-        </p>
+          <span
+            style={{
+              fontSize: "3.4vh",
+              fontWeight: "bold",
+              margin: "0 auto",
+            }}
+          >
+            {displayedUser.name}
+          </span>
+        </div>
       </div>
       <div
         style={{


### PR DESCRIPTION
# PRの概要

「その他」などと表示され何のことかわからないので「性別」「学年」などのラベルをつけた。
あとはデザイン的にちょっとスカスカしていたのでなんか入れるとちょっと見栄えが良くなるかもという。

## 具体的な変更内容

長い場合

<img width="332" alt="image" src="https://github.com/user-attachments/assets/13940d65-b923-4d25-ae78-6889ab708d0d">

短い場合

<img width="332" alt="image" src="https://github.com/user-attachments/assets/391daa91-db23-4c02-bea4-d6378a811bb8">



## 影響範囲

カード内

## レビューリクエストを出す前にチェック！

- [x] 改めてセルフレビューしたか
- [x] 手動での動作検証を行ったか
- [x] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [x] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [x] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
