### PR TITLE
Homeでユーザー取得時にloading画面にする

### DIFF
--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -77,13 +77,13 @@ export default function Home() {
     [recommended, controls, backCardControls],
   );
 
-  if (recommended == null) {
+  if (data === undefined) {
     return <FullScreenCircularProgress />;
   }
   if (currentUser == null) {
     return <FullScreenCircularProgress />;
   }
-  if (displayedUser == null) {
+  if (recommended.size() === 0) {
     return <NoMoreUser />;
   }
   if (error) throw error;
@@ -172,5 +172,8 @@ class Queue<T> {
   }
   pop(): T | undefined {
     return this.store.shift();
+  }
+  size(): number {
+    return this.store.length;
   }
 }


### PR DESCRIPTION
# PRの概要
closes #664 
## 具体的な変更内容
Home画面のユーザー取得時に<FullScreenCircularProgress />が出ないようにし、代わりに<NoMoreUsers />が表示されるようにした。

## 影響範囲

## 動作要件

## 補足

## レビューリクエストを出す前にチェック！

- [ ] 改めてセルフレビューしたか
- [ ] 手動での動作検証を行ったか
- [ ] server の機能追加ならば、テストを書いたか
  - 理由: 書いた | server の機能追加ではない
- [ ] 間違った使い方が存在するならば、それのドキュメントをコメントで書いたか
  - 理由: 書いた | 間違った使い方は存在しない
- [ ] わかりやすいPRになっているか

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
